### PR TITLE
Bugfix/remove lowercasing pkg from uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ LATEST_CHANGELOG.md
 __pycache__
 .git-commit-template
 .vscode/
+.idea/
 .venv/
 docs/source/api/
 docs/source/commands/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- start-here-sphinx-start-after -->
 
+## 2.114.2 (2024-12-28)
+
+- Fix package URIs being converted to lowercase in Windows, breaking package caching.
+
 ## 2.114.1 (2023-12-09)
 [Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.114.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.114.0...2.114.1)
 

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -4,4 +4,4 @@
 
 # Update this value to version up Rez. Do not place anything else in this file.
 # Using .devN allows us to run becnmarks and create proper benchmark reports on PRs.
-_rez_version = "2.114.1"
+_rez_version = "2.114.2"

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -12,6 +12,7 @@ import stat
 import errno
 import time
 import shutil
+from pathlib import Path
 
 from rez.package_repository import PackageRepository
 from rez.package_resources import PackageFamilyResource, VariantResourceHelper, \
@@ -598,14 +599,14 @@ class FileSystemPackageRepository(PackageRepository):
         - /svr/packages/mypkg/package.py  # (unversioned package - rare)
         - /svr/packages/mypkg/package.py<1.0.0>  # ("combined" package type - rare)
         """
-        uri = os.path.normcase(uri)
+        uri = Path(uri)
 
         prefix = self.location + os.path.sep
-        if not is_subdirectory(uri, prefix):
+        if not is_subdirectory(str(uri), prefix):
             return None
 
-        part = uri[len(prefix):]  # eg 'mypkg/1.0.0/package.py'
-        parts = part.split(os.path.sep)
+        part = uri.relative_to(Path(prefix))  # eg 'mypkg/1.0.0/package.py'
+        parts = uri.parts
         pkg_name = parts[0]
 
         if len(parts) == 2:

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -605,8 +605,7 @@ class FileSystemPackageRepository(PackageRepository):
         if not is_subdirectory(str(uri), prefix):
             return None
 
-        part = uri.relative_to(Path(prefix))  # eg 'mypkg/1.0.0/package.py'
-        parts = uri.parts
+        parts = uri.relative_to(Path(prefix)).parts  # eg (mypkg, 1.0.0, package.py)
         pkg_name = parts[0]
 
         if len(parts) == 2:


### PR DESCRIPTION
In the `get_package_from_uri()` function, Rez is calling `os.path.normcase()` on the package's URI path, which on Windows, converts all '\' to '/' AND makes the entire path lowercase, since Windows paths are case insensitive.

Rez then proceeds to do a case sensitive search for the package name as it continues.

So, so sum that up, rez's package caching is failing because it's taking "PySide2", converting it to "pyside2", then complaining that the all lowercase path doesn't exist in the package repo. This problem is specific to Windows, as os.path.normcase() does not convert the path to all lowercase in other platforms.