### PR TITLE
Platform remapping platform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
 
-  # https://github.com/dependabot/dependabot-core/issues/6704
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-python"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
-
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:

--- a/.github/scripts/store_benchmark.py
+++ b/.github/scripts/store_benchmark.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import os.path
 import json

--- a/.github/scripts/validate_benchmark.py
+++ b/.github/scripts/validate_benchmark.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os.path
 import sys
 import json

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     name: run_benchmark
@@ -22,13 +25,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: ./.github/actions/setup-python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
-          os: ubuntu-latest
 
       - name: Install Rez
         run: |
@@ -47,7 +49,7 @@ jobs:
         run: |
           python ./.github/scripts/validate_benchmark.py
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: "benchmark-result-${{ matrix.python-version }}"
           path: ./out
@@ -66,13 +68,13 @@ jobs:
       max-parallel: 1
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: "benchmark-result-${{ matrix.python-version }}"
           path: .
 
       - name: Checkout (release)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: ${{ github.event_name =='release' }}
         with:
           ref: main
@@ -86,16 +88,15 @@ jobs:
           # token: "${{ secrets.GH_ACTION_TOKEN }}"
 
       - name: Checkout (pr)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: ${{ github.event_name !='release' }}
         with:
           path: src
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: ./src/.github/actions/setup-python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
-          os: ubuntu-latest
 
       # Note failing due to
       # https://github.com/actions/virtual-environments/issues/675

--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -10,6 +10,9 @@ on:
       - '!**.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Enforce copyright notices
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3
 

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -19,6 +19,9 @@ on:
       - '!src/rez/vendor/**'
       - '!src/rez/backport/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linter
@@ -26,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -3,16 +3,27 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'install.py'
+      - 'setup.py'
+      - 'MANIFEST.in'
+      - 'pyproject.toml'
       - '.github/workflows/installation.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
   push:  
     paths:
       - 'src/**'
+      - 'install.py'
+      - 'setup.py'
+      - 'MANIFEST.in'
+      - 'pyproject.toml'
       - '.github/workflows/installation.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   main:
@@ -22,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         method: ['install' ,'pip']
 
         include:
@@ -30,83 +41,50 @@ jobs:
         - os: ubuntu-latest
           method: install
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:/opt/rez/bin/rez'
-          REZ_INSTALL_COMMAND: |
-            set -ex
-            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
-                conda activate python
-            fi
-            python ./install.py /opt/rez
-
+          REZ_INSTALL_COMMAND: python ./install.py /opt/rez
         - os: ubuntu-latest
           method: pip
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
-          REZ_INSTALL_COMMAND: |
-            set -ex
-            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
-                conda activate python
-            fi
-            pip install --target /opt/rez .
+          REZ_INSTALL_COMMAND: pip install --target /opt/rez .
         # macOS
         - os: macos-latest
           method: install
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:~/rez/bin/rez'
-          REZ_INSTALL_COMMAND: |
-            set -e
-            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
-                conda activate python
-
-                echo "otool -L $(dirname $(which python))/../lib/libpython2.7.dylib"
-                otool -L $(dirname $(which python))/../lib/libpython2.7.dylib
-                echo "otool -l $(dirname $(which python))/../lib/libpython2.7.dylib"
-                otool -l $(dirname $(which python))/../lib/libpython2.7.dylib
-            fi
-
-            python ./install.py ~/rez
+          REZ_INSTALL_COMMAND: python ./install.py ~/rez
         - os: macos-latest
           method: pip
           REZ_SET_PATH_COMMAND: 'export PATH="$PATH:~/rez/bin" PYTHONPATH=$PYTHONPATH:$HOME/rez'
-          REZ_INSTALL_COMMAND: |
-            set -ex
-            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
-                conda activate python
-            fi
-            pip install --target ~/rez .
+          REZ_INSTALL_COMMAND: pip install --target ~/rez .
+        # macOS
+        # Python 3.7 is not supported on Apple Silicon.
+        # macos-13 is the last macos runner image to run on Intel CPUs.
+        - os: macos-13
+          python-version: '3.7'
+          method: install
+          REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:~/rez/bin/rez'
+          REZ_INSTALL_COMMAND: python ./install.py ~/rez
+        - os: macos-13
+          python-version: '3.7'
+          method: pip
+          REZ_SET_PATH_COMMAND: 'export PATH="$PATH:~/rez/bin" PYTHONPATH=$PYTHONPATH:$HOME/rez'
+          REZ_INSTALL_COMMAND: pip install --target ~/rez .
         # windows
         - os: windows-latest
           method: install
           REZ_SET_PATH_COMMAND: '$env:PATH="$env:PATH;C:\ProgramData\rez\Scripts\rez"'
-          REZ_INSTALL_COMMAND: |
-            if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
-                conda activate python
-            }
-            python ./install.py C:\ProgramData\rez
+          REZ_INSTALL_COMMAND: python ./install.py C:\ProgramData\rez
         - os: windows-latest
           method: pip
           REZ_SET_PATH_COMMAND: '[System.Environment]::SetEnvironmentVariable("PATH","$env:PATH;C:\ProgramData\rez\bin"); $env:PYTHONPATH="$env:PYTHONPATH;C:\ProgramData\rez"'
-          REZ_INSTALL_COMMAND: |
-            if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
-                conda activate python
-            }
-            pip install --target C:\ProgramData\rez .
-
-        exclude:
-        - method: install
-          python-version: '2.7'
+          REZ_INSTALL_COMMAND: pip install --target C:\ProgramData\rez .
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup python ${{ matrix.python-version }}
-      uses: ./.github/actions/setup-python
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
-        os: ${{ matrix.os }}
 
     - name: Install
       env:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,6 +3,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to PyPI
@@ -11,13 +14,15 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      # Not sure if it's needed here since it's defined at the top level.
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.11
 
@@ -32,6 +37,6 @@ jobs:
       # Note that we don't need credentials.
       # We rely on https://docs.pypi.org/trusted-publishers/.
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           packages-dir: dist

--- a/.github/workflows/release-notice.yaml
+++ b/.github/workflows/release-notice.yaml
@@ -1,0 +1,24 @@
+name: slack-notification
+
+on:
+  release:
+    types:
+      # published should cover both 'released' and 'prereleased'
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Notify Slack
+      id: slack
+      with:
+        project_name: "rez"
+        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel: "#release-announcements"
+        project_logo: "https://artwork.aswf.io/projects/rez/icon/black/rez-icon-black.png"
+      uses: jmertic/slack-release-notifier@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,66 @@
+name: OpenSSF Scorecard
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '21 4 * * 3'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,12 +3,20 @@ on:
   pull_request:
     paths:
     - 'src/**'
+    - 'install.py'
+    - 'setup.py'
+    - 'MANIFEST.in'
+    - 'pyproject.toml'
     - '.github/workflows/tests.yaml'
     - '!src/rez/utils/_version.py'
     - '!**.md'
   push:
     paths:
     - 'src/**'
+    - 'install.py'
+    - 'setup.py'
+    - 'MANIFEST.in'
+    - 'pyproject.toml'
     - '.github/workflows/tests.yaml'
     - '!src/rez/utils/_version.py'
     - '!**.md'
@@ -17,6 +25,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   core:
@@ -27,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
         - os: macos-latest
           shells: 'sh,csh,bash,tcsh,zsh,pwsh'
@@ -38,15 +49,21 @@ jobs:
         - os: windows-latest
           shells: 'cmd,pwsh,gitbash'
           rez-path: \installdir\Scripts\rez
+        # Python 3.7 is not supported on Apple Silicon.
+        # macos-13 is the last macos runner image to run on Intel CPUs.
+        - os: macos-13
+          shells: 'sh,csh,bash,tcsh,zsh,pwsh'
+          rez-path: /installdir/bin/rez
+          python-version: '3.7'
 
       fail-fast: false
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -75,6 +92,16 @@ jobs:
       run: rez-python -m pip install pytest-cov parameterized
 
     - name: Run tests
-      run: rez-selftest -v
+      id: tests
+      run: rez-selftest -v -- --cov=rez --cov-report=xml:coverage.xml
       env:
         _REZ_ENSURE_TEST_SHELLS: ${{ matrix.shells }}
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
+      # Run on both success and failure, but only if coverage.xml exists.
+      if: ${{ hashFiles('coverage.xml') != '' && (steps.tests.outcome == 'success' || steps.tests.outcome == 'failure') }}
+      with:
+        slug: AcademySoftwareFoundation/rez
+        files: 'coverage.xml'
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -72,7 +72,7 @@ def bind(path, version_range=None, opts=None, parser=None):
         binpath = make_dirs(root, "bin")
         link = os.path.join(binpath, "python")
         # Symlinks to python2 on windows break python, so we copy the exe
-        if platform_.name == "windows" and str(version.major) == "2":
+        if platform_.system == "windows" and str(version.major) == "2":
             link += ".exe"
             shutil.copy(exepath, link)
         else:

--- a/src/rez/bundle_context.py
+++ b/src/rez/bundle_context.py
@@ -195,7 +195,7 @@ class _ContextBundler(object):
 
     def _patch_libs(self):
         # TODO
-        if platform_.name in ("osx", "windows"):
+        if platform_.system in ("darwin", "windows"):
             return
 
         self._patch_libs_linux()

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -22,11 +22,20 @@ class System(object):
         return __version__
 
     @cached_property
+    def name(self):
+        """Get the current actual platform system name, in lowercase.
+
+        Returns:
+            The current system platform, ignoring platform map (windows, linux, darwin).
+        """
+        return platform_.system
+
+    @cached_property
     def platform(self):
         """Get the current platform.
 
         Returns:
-            The current platform (windows, linux, osx, etc).
+            The current mapped platform (windows, linux, osx, etc).
         """
         return platform_.name
 

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -9,7 +9,7 @@ from rez.build_process import create_build_process
 from rez.build_system import create_build_system
 from rez.resolved_context import ResolvedContext
 from rez.shells import get_shell_class
-from rez.exceptions import BuildError, BuildContextResolveError,\
+from rez.exceptions import BuildError, BuildContextResolveError, \
     PackageFamilyNotFoundError
 import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -201,7 +201,7 @@ class TestBuild(TestBase, TempdirMixin):
     @install_dependent()
     def test_build_cmake(self):
         """Test a cmake-based package."""
-        if platform_.name == "windows":
+        if platform_.system == "windows":
             self.skipTest("This test does not run on Windows due to temporary"
                           "limitations of the cmake build_system plugin"
                           " implementation.")
@@ -211,7 +211,7 @@ class TestBuild(TestBase, TempdirMixin):
         self._test_build_translate_lib()
         self._test_build_sup_world()
 
-    @unittest.skipIf(platform_.name == "windows", "Skipping because make and GCC are not common on Windows")
+    @unittest.skipIf(platform_.system == "windows", "Skipping because make and GCC are not common on Windows")
     @program_dependent("make", "g++")
     def test_build_custom(self):
         """Test a make-based package that uses the custom_build attribute."""

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -60,7 +60,7 @@ class TestContext(TestBase, TempdirMixin):
     # TODO make shell-dependent (wait until port to pytest)
     def test_execute_command(self):
         """Test command execution in context."""
-        if platform_.name == "windows":
+        if platform_.system == "windows":
             self.skipTest("This test does not run on Windows due to problems"
                           " with the automated binding of the 'hello_world'"
                           " executable.")

--- a/src/rez/tests/test_e2e_shells.py
+++ b/src/rez/tests/test_e2e_shells.py
@@ -90,7 +90,7 @@ class TestShells(TestBase, TempdirMixin):
         if CI:
             if shell != "cmd":
                 return
-        elif platform_.name in ["linux", "darwin"] and shell == "pwsh":
+        elif platform_.system in ["linux", "darwin"] and shell == "pwsh":
             return
 
         config.override("enable_path_normalization", False)

--- a/src/rez/tests/test_e2e_shells.py
+++ b/src/rez/tests/test_e2e_shells.py
@@ -17,7 +17,7 @@ from rez.exceptions import PackageFamilyNotFoundError
 from rez.shells import create_shell
 from rez.resolved_context import ResolvedContext
 from rez.tests.util import TestBase, TempdirMixin, per_available_shell
-from rez.utils import platform_
+from rez.utils.platform_ import platform_
 from rez.utils.filesystem import canonical_path
 import unittest
 import subprocess

--- a/src/rez/tests/test_utils.py
+++ b/src/rez/tests/test_utils.py
@@ -13,7 +13,7 @@ from rez.tests.util import TestBase, platform_dependent
 from rez.utils import cygpath, filesystem
 from rez.utils.platform_ import Platform, platform_
 
-if platform_.name == "windows":
+if platform_.system == "windows":
     from rez.utils import uncpath
     uncpath_available = True
 else:
@@ -38,7 +38,7 @@ class TestCanonicalPath(TestBase):
             return False
 
     def test_win32_case_insensitive(self):
-        if platform_.name != 'windows':
+        if platform_.system != 'windows':
             self.skipTest('on linux/macos, `os.path.realpath()` treats windows '
                           'abspaths as relpaths, and prepends `os.getcwd()`')
         platform = self.CaseInsensitivePlatform()
@@ -47,7 +47,7 @@ class TestCanonicalPath(TestBase):
         self.assertEqual(path, expects)
 
     def test_unix_case_sensistive_platform(self):
-        if platform_.name == 'windows':
+        if platform_.system == 'windows':
             self.skipTest('on windows, `os.path.realpath()` treats unix abspaths '
                           'as relpaths, and prepends `os.getcwd()`')
         platform = self.CaseSensitivePlatform()
@@ -56,7 +56,7 @@ class TestCanonicalPath(TestBase):
         self.assertEqual(path, expects)
 
     def test_unix_case_insensistive_platform(self):
-        if platform_.name == 'windows':
+        if platform_.system == 'windows':
             self.skipTest('on windows, `os.path.realpath()` treats unix abspaths '
                           'as relpaths, and prepends `os.getcwd()`')
         platform = self.CaseInsensitivePlatform()

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -9,7 +9,7 @@ from rez import module_root_path
 from rez.config import config, _create_locked_config
 from rez.shells import get_shell_types, get_shell_class
 from rez.system import system
-from rez.utils import platform_
+from rez.utils.platform_ import platform_
 import tempfile
 import threading
 import time

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -357,7 +357,7 @@ def platform_dependent(platforms):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            if platform_.name in platforms:
+            if platform_.system in platforms:
                 return func(self, *args, **kwargs)
             else:
                 self.skipTest("Must be run on platform(s): %s" % platforms)

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -4,4 +4,4 @@
 
 # Update this value to version up Rez. Do not place anything else in this file.
 # Using .devN allows us to run becnmarks and create proper benchmark reports on PRs.
-_rez_version = "2.114.3"
+_rez_version = "2.114.4"

--- a/src/rez/utils/cygpath.py
+++ b/src/rez/utils/cygpath.py
@@ -16,7 +16,7 @@ from rez.config import config
 from rez.utils import platform_
 from rez.utils.logging_ import print_debug
 
-if platform_.name == "windows":
+if platform_.system == "windows":
     from rez.utils import uncpath
     uncpath_available = True
 else:

--- a/src/rez/utils/cygpath.py
+++ b/src/rez/utils/cygpath.py
@@ -13,8 +13,8 @@ import posixpath
 import re
 
 from rez.config import config
-from rez.utils import platform_
 from rez.utils.logging_ import print_debug
+from rez.utils.platform_ import platform_
 
 if platform_.system == "windows":
     from rez.utils import uncpath

--- a/src/rez/utils/graph_utils.py
+++ b/src/rez/utils/graph_utils.py
@@ -272,7 +272,7 @@ def view_graph(graph_str, dest_file=None):
     from rez.system import system
     from rez.config import config
 
-    if (system.platform == "linux") and (not os.getenv("DISPLAY")):
+    if (system.name == "linux") and (not os.getenv("DISPLAY")):
         print("Unable to open display.", file=sys.stderr)
         sys.exit(1)
 

--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -6,7 +6,6 @@
 Python packaging related utilities.
 """
 import os.path
-import re
 from email.parser import Parser
 
 import pkg_resources
@@ -514,19 +513,11 @@ def convert_distlib_to_setuptools(installed_dist):
     Returns:
         `pkg_resources.DistInfoDistribution`: Equivalent setuptools dist object.
     """
-    def normalize(name):
-        """Convert an arbitrary string to a normalized package distribution name.
-
-        Following this normalization rule:
-        https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
-        """
-        return re.sub(r"[-_.]+", "-", name).lower()
-
     path = os.path.dirname(installed_dist.path)
     setuptools_dists = pkg_resources.find_distributions(path)
 
     for setuptools_dist in setuptools_dists:
-        if normalize(setuptools_dist.key) == normalize(installed_dist.key):
+        if setuptools_dist.key == pkg_resources.safe_name(installed_dist.key):
             return setuptools_dist
 
     return None

--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -6,6 +6,7 @@
 Python packaging related utilities.
 """
 import os.path
+import re
 from email.parser import Parser
 
 import pkg_resources
@@ -513,11 +514,19 @@ def convert_distlib_to_setuptools(installed_dist):
     Returns:
         `pkg_resources.DistInfoDistribution`: Equivalent setuptools dist object.
     """
+    def normalize(name):
+        """Convert an arbitrary string to a normalized package distribution name.
+
+        Following this normalization rule:
+        https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
+        """
+        return re.sub(r"[-_.]+", "-", name).lower()
+
     path = os.path.dirname(installed_dist.path)
     setuptools_dists = pkg_resources.find_distributions(path)
 
     for setuptools_dist in setuptools_dists:
-        if setuptools_dist.key == pkg_resources.safe_name(installed_dist.key):
+        if normalize(setuptools_dist.key) == normalize(installed_dist.key):
             return setuptools_dist
 
     return None

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -33,7 +33,7 @@ class Platform(object):
     def name(self):
         """Returns the name of the platform."""
         return self._name()
-    
+
     @cached_property
     @platform_mapped
     def arch(self):

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -19,11 +19,21 @@ from tempfile import gettempdir
 class Platform(object):
     """Abstraction of a platform.
     """
-    name = None
 
     def __init__(self):
         pass
 
+    @cached_property
+    def system(self):
+        """Returns the lowercase non-mapped name of the system OS."""
+        return platform.system().lower()
+
+    @cached_property
+    @platform_mapped
+    def name(self):
+        """Returns the name of the platform."""
+        return self._name()
+    
     @cached_property
     @platform_mapped
     def arch(self):
@@ -115,6 +125,9 @@ class Platform(object):
 
     # -- implementation
 
+    def _name(self):
+        return platform.system().lower()
+
     def _arch(self):
         return platform.machine()
 
@@ -170,7 +183,7 @@ class Platform(object):
 
 
 # -----------------------------------------------------------------------------
-# Unix (Linux and OSX)
+# Unix (Linux and macOS)
 # -----------------------------------------------------------------------------
 
 class _UnixPlatform(Platform):
@@ -183,7 +196,6 @@ class _UnixPlatform(Platform):
 # -----------------------------------------------------------------------------
 
 class LinuxPlatform(_UnixPlatform):
-    name = "linux"
 
     def _os(self):
         """
@@ -406,11 +418,12 @@ class LinuxPlatform(_UnixPlatform):
 
 
 # -----------------------------------------------------------------------------
-# OSX
+# macOS
 # -----------------------------------------------------------------------------
 
-class OSXPlatform(_UnixPlatform):
-    name = "osx"
+class MacPlatform(_UnixPlatform):
+    def _name(self):
+        return "osx"
 
     def _os(self):
         release = platform.mac_ver()[0]
@@ -433,7 +446,7 @@ class OSXPlatform(_UnixPlatform):
     def _editor(self):
         return "open"
 
-    def _physical_cores_from_osx_sysctl(self):
+    def _physical_cores_from_mac_sysctl(self):
         import subprocess
         try:
             p = Popen(
@@ -451,7 +464,7 @@ class OSXPlatform(_UnixPlatform):
         return int(stdout.strip())
 
     def _physical_cores(self):
-        return self._physical_cores_from_osx_sysctl()
+        return self._physical_cores_from_mac_sysctl()
 
     def _difftool(self):
         from rez.util import which
@@ -463,7 +476,6 @@ class OSXPlatform(_UnixPlatform):
 # -----------------------------------------------------------------------------
 
 class WindowsPlatform(Platform):
-    name = "windows"
 
     def _arch(self):
         # http://stackoverflow.com/questions/7164843/in-python-how-do-you-determine-whether-the-kernel-is-running-in-32-bit-or-64-bi
@@ -570,6 +582,6 @@ name = platform.system().lower()
 if name == "linux":
     platform_ = LinuxPlatform()
 elif name == "darwin":
-    platform_ = OSXPlatform()
+    platform_ = MacPlatform()
 elif name == "windows":
     platform_ = WindowsPlatform()

--- a/src/rez/utils/platform_mapped.py
+++ b/src/rez/utils/platform_mapped.py
@@ -36,8 +36,8 @@ def platform_mapped(func):
         # Original result
         result = func(*args, **kwargs)
 
-        # The function name is used as primary key
-        entry = config.platform_map.get(func.__name__)
+        # The function name is used as primary key, except for "name", which is set to "platform".
+        entry = config.platform_map.get("platform" if func.__name__ == "name" else func.__name__)
         if entry:
             for key, value in entry.items():
                 result, changes = re.subn(key, value, result)


### PR DESCRIPTION
Allow platform to be remapped using rez config's "platform_map" setting, which previously only allowed the "os" and "arch" implicits to be remapped.